### PR TITLE
Fix broken fenced layout on Jekyll

### DIFF
--- a/_posts/2015-06-03-announcing-gittorrent.md
+++ b/_posts/2015-06-03-announcing-gittorrent.md
@@ -149,6 +149,7 @@ $ git clone gittorrent://github.com/cjb/foo
 ```
 
 そして次のように変わり:
+
 ```console
 $ git clone gittorrent://81e24205d4bac8496d3e13282c90ead5045f09ea/foo
 ```

--- a/_posts/2015-06-09-xmonad-with-ubuntu-vivid.md
+++ b/_posts/2015-06-09-xmonad-with-ubuntu-vivid.md
@@ -36,6 +36,7 @@ Ubuntu 14.10まではxmonadのパッケージをインストールするとXMona
 これも15.04で消されたファイルの一つである。もっとも14.10ではこのファイルは存在してたが、 `gnome-setting-daemon` を `unity-settings-daemon` に変更したり `DesktopName=Unity` を追加しないと正しく動かなかったため結局 `/usr/local` 以下に似たようなファイルを置く必要があった記憶がある。
 
 以上の手順を踏んでもデスクトップが出るまで異常に時間がかかったりうまく動かなかったりした場合には `~/.xmonad/lib/XMonad/Config/Gnome.hs` に以下の内容を保存しよう:
+
 ```haskell
 {-# OPTIONS_GHC -fno-warn-missing-signatures #-}
 
@@ -120,6 +121,7 @@ gnomeRegister = io $ do
             ,"string:xmonad"
             ,"string:"++sessionId]
 ```
+
 これは[XMonadとGnomeを連携させるためのモジュール](//xmonad.org/xmonad-docs/xmonad-contrib/XMonad-Config-Gnome.html)だが、残念ながらxmonadのパッケージにあらかじめあるコードでは動かない。どうやら `dbus-send` の仕様が変わり、77行目が本来 `--print-reply=literal` にするべきなのが `--print-reply=string` になってるのが原因なのでオリジナルのソースからそこだけ変更してある。この修正が必要な場合は、確か `~/.xsession-errors` にdbus関連のエラーが出現するはずだから一応確認してみるのもいいかもしれない。どうやら去年の段階で[パッチが送られてる様子](//mail.haskell.org/pipermail/xmonad/2014-May/014130.html)なのでこのファイルを自分で用意する必要はそろそろなくなるだろう。
 
 # Super+Pキーコンビネーションについて

--- a/_posts/2015-08-11-ja-fonts-in-ubuntu.md
+++ b/_posts/2015-08-11-ja-fonts-in-ubuntu.md
@@ -14,6 +14,7 @@ Linux環境ではフォントの設定はFontconfigで管理するのが主流�
 
 # 今回の解決策
 では従来まとめれていた日本語向けフォント設定は一体どうなってしまったのかというと、各フォント個別の設定として分散されている。例えば、Takao ゴシックというフォントに関する設定が記述されてる `/etc/fonts/conf.avail/65-fonts-takao-gothic.conf` を見ると次のような記述がある:
+
 ```xml
 <match target="pattern">
   <test name="lang" compare="contains">
@@ -27,30 +28,39 @@ Linux環境ではフォントの設定はFontconfigで管理するのが主流�
   </edit>
 </match>
 ```
+
 この設定により日本語環境下ではmonospaceフォントととしてTakao ゴシックが優先されるようになる。すなわち、ロケールに合わせてフォント選択の挙動が変化するように設定されてるのである。このようなロケールに合わせたフォント設定に関しては[Fedoraのウィキ](//fedoraproject.org/wiki/Fontconfig_packaging_tips#Locale-specific_overrides)に詳しく書いてあるので参考にするといいだろう。
 
 ではロケールに合わせてフォント選択が変わってしまうならば、どうやって英語ロケールで日本語に適したフォントを選択させればいいのか。それはFontconfigが言語を調べるときの挙動に着目すればいい。[ここ](//www.freedesktop.org/software/fontconfig/fontconfig-devel/fcgetdefaultlangs.html)を見ると、どうやらFontconfigは `FC_LANG` 、 `LC_ALL` 、 `LC_CTYPE` 、 `LANG` の順番に環境変数を調べるようである。したがって、環境変数  `FC_LANG` を日本語に設定していれば `LANG` 英語になっていようと日本語に適したフォントが選択されることになる。試しに異なる環境変数で `fc-match` コマンドを叩き、システムのデフォルトフォントがどう変化するか調べてみた。まずは通常の日本語ロケールの場合から:
+
 ```console
 $ env -i LANG=ja_JP.UTF-8 fc-match
 fonts-japanese-gothic.ttf: "Takao Pゴシック" "Regular"
 ```
+
 `env` コマンドに `-i` オプションを渡すと空の環境から始めることが出来る。すなわち、 `FC_LANG` が設定されてない状態で `LANG` が `ja_JP.UTF-8` に設定され場合、Takao Pゴシックがデフォルトフォントに選択されることを示してる。次も同様に通常の英語ロケールについて:
+
 ```console
 $ env -i LANG=en_US.UTF-8 fc-match
 DejaVuSans.ttff: "DejaVu Sans" "Book"
 ```
+
 今回は変わってDejaVu Sansが採用されてるのが分かる。では、英語ロケールで `FC_LANG` を `ja` に設定したらどうだろうか。
+
 ```console
 $ env LANG=en_US.UTF-8 FC_LANG=ja fc-match
 fonts-japanese-gothic.ttf: "Takao Pゴシック" "Regular"
 ```
+
 ちゃんとTakao Pゴシックが選択され、日本語に適したフォントが選択されてることが分かる。
 
 # 結論
 環境変数 `FC_LANG` を `ja` に設定しよう。 `~/.profile` に一行
+
 ```sh
 export FC_LANG=ja
 ```
+
 と追加すれば良い。最後に、環境変数を設定する前後を比較してみる。次が設定する前のフォントである:
 
 ![]({{ site.baseurl }}/img/2015-08/badfont.png "設定前")


### PR DESCRIPTION
- justify GFM Fenced code blocks syntax